### PR TITLE
On accepted status_code, still parse data

### DIFF
--- a/dolib/client.py
+++ b/dolib/client.py
@@ -125,7 +125,6 @@ class Client(BaseClient):
         response = self.request_raw(endpoint, method, params, json, data)
         if response.status_code in [
             requests.codes["no_content"],
-            requests.codes["accepted"],
         ]:
             return {}
         return response.json()
@@ -232,7 +231,6 @@ class AsyncClient(BaseClient):
         response = await self.request_raw(endpoint, method, params, json, data)
         if response.status_code in [
             requests.codes["no_content"],
-            requests.codes["accepted"],
         ]:
             return {}
         return response.json()


### PR DESCRIPTION
Calls like creating a Droplet will return an accept with the information about
the created droplet. We need to parse in those cases.